### PR TITLE
fix(ent proto): fix casing when generating grpc services

### DIFF
--- a/entproto/cmd/protoc-gen-entgrpc/template/method_batch_create.tmpl
+++ b/entproto/cmd/protoc-gen-entgrpc/template/method_batch_create.tmpl
@@ -10,7 +10,7 @@
     }
     bulk := make([]*ent.{{ .G.EntType.Name }}Create, len(requests))
     for i, req := range requests {
-        {{ $reqVar }} := req.Get{{ .G.EntType.Name }}()
+        {{ $reqVar }} := req.Get{{ $reqVar }}()
         var err error
         bulk[i], err = svc.createBuilder({{ $reqVar }})
         if err != nil {

--- a/entproto/cmd/protoc-gen-entgrpc/template/method_list.tmpl
+++ b/entproto/cmd/protoc-gen-entgrpc/template/method_list.tmpl
@@ -65,7 +65,7 @@
             return nil, {{ statusErrf "Internal" "internal error: %s" "err" }}
         }
         return &List{{ .G.EntType.Name }}Response{
-            {{ .G.EntType.Name }}List: protoList,
+            {{ camel .G.EntType.Name }}List: protoList,
             NextPageToken: nextPageToken,
         }, nil
     default:

--- a/entproto/cmd/protoc-gen-entgrpc/template/method_mutate.tmpl
+++ b/entproto/cmd/protoc-gen-entgrpc/template/method_mutate.tmpl
@@ -6,7 +6,7 @@
     {{- $inputName := .Method.Input.GoIdent.GoName -}}
     {{- $methodName := .Method.GoName -}}
     {{- $reqVar := camel .G.EntType.Name -}}
-    {{ $reqVar }} := req.Get{{ .G.EntType.Name }}()
+    {{ $reqVar }} := req.Get{{ $reqVar }}()
     {{- if eq .Method.GoName "Create" }}
         m, err := svc.createBuilder({{ $reqVar }})
         if err != nil {


### PR DESCRIPTION
Fix casing when generating grpc services:
This matters for interfaces, like `userI` will have get a getter: `getUseri` instead of `getUserI`. This is because of how protoc creates types method signatures. 