### PR TITLE
fix(schemast): add field type imports explicitly instead of via goimports

### DIFF
--- a/schemast/field.go
+++ b/schemast/field.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"entgo.io/ent/schema/field"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 // Field converts a *field.Descriptor back into an *ast.CallExpr of the ent field package that can be used
@@ -81,7 +82,33 @@ func (c *Context) AppendField(typeName string, desc *field.Descriptor) error {
 	if err != nil {
 		return err
 	}
-	return c.appendReturnItem(kindField, typeName, newField)
+	if err := c.appendReturnItem(kindField, typeName, newField); err != nil {
+		return err
+	}
+	c.addFieldImport(typeName, desc)
+	return nil
+}
+
+// addFieldImport ensures the package that provides a field's Go type is imported
+// in the file declaring typeName. The import is added explicitly rather than
+// left for goimports to infer from a bare usage such as uuid.UUID{}: as of
+// golang.org/x/tools v0.47.0 goimports mis-resolves such usages to the bare
+// package name ("uuid") instead of its full path ("github.com/google/uuid"),
+// which produces an unbuildable schema and breaks ent codegen.
+func (c *Context) addFieldImport(typeName string, desc *field.Descriptor) {
+	pkgPath := ""
+	if desc.Info.RType != nil {
+		pkgPath = desc.Info.RType.PkgPath
+	}
+	if pkgPath == "" && desc.Info.Type == field.TypeUUID {
+		pkgPath = "github.com/google/uuid"
+	}
+	if pkgPath == "" {
+		return
+	}
+	if file, _, ok := c.lookupTypeDecl(typeName); ok {
+		astutil.AddImport(c.SchemaPackage.Fset, file, pkgPath)
+	}
 }
 
 // RemoveField removes a field from the returned values of the Fields method of type typeName.

--- a/schemast/mutate.go
+++ b/schemast/mutate.go
@@ -16,11 +16,9 @@ package schemast
 
 import (
 	"go/ast"
-	"go/token"
 
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
-	"entgo.io/ent/schema/field"
 )
 
 // Mutator changes a Context.
@@ -59,17 +57,9 @@ func (u *UpsertSchema) Mutate(ctx *Context) error {
 		return err
 	}
 	for _, fld := range u.Fields {
+		// AppendField also adds any import required by the field's Go type.
 		if err := ctx.AppendField(u.Name, fld.Descriptor()); err != nil {
 			return err
-		}
-		if fld.Descriptor().Info.Type == field.TypeUUID {
-			ctx.appendImport(u.Name, "github.com/google/uuid")
-		}
-		// Append any imported struct for JSON fields
-		if fld.Descriptor().Info.Type == field.TypeJSON {
-			if fld.Descriptor().Info.RType != nil && fld.Descriptor().Info.RType.PkgPath != "" {
-				ctx.appendImport(u.Name, fld.Descriptor().Info.RType.PkgPath)
-			}
 		}
 	}
 	for _, edg := range u.Edges {
@@ -115,10 +105,4 @@ func (c *Context) appendReturnItem(k kind, typeName string, item ast.Expr) error
 		return err
 	}
 	return appendToReturn(stmt, k.ifaceSelector, item)
-}
-
-func (c *Context) appendImport(typeName, pkgPath string) {
-	if f, ok := c.newTypes[typeName]; ok {
-		f.Imports = append(f.Imports, &ast.ImportSpec{Path: &ast.BasicLit{Value: pkgPath, Kind: token.STRING}})
-	}
 }


### PR DESCRIPTION
AppendField relied on schemast.Print's goimports pass to infer the import for a field's Go type (e.g. github.com/google/uuid for field.UUID) from a bare uuid.UUID{} usage. The old appendImport only wrote to ast.File.Imports (which the printer ignores) and only for newly created types, so the import never reached the printed source.

As of golang.org/x/tools v0.47.0 goimports mis-resolves such inferred imports to the bare package name ("uuid") instead of the full path ("github.com/google/uuid"), producing an unbuildable schema and breaking ent codegen downstream.

Add the required import to the actual import declaration via astutil.AddImport in AppendField, covering new and existing types and any field with a foreign Go type. Remove the now-dead appendImport helper and the redundant per-field blocks in Mutate.